### PR TITLE
FIX: image sending leaking sender data

### DIFF
--- a/src/api/commands/listingitemtemplate/ListingItemTemplatePostCommand.ts
+++ b/src/api/commands/listingitemtemplate/ListingItemTemplatePostCommand.ts
@@ -278,6 +278,8 @@ export class ListingItemTemplatePostCommand extends BaseCommand implements RpcCo
 
             // send each image related to the ListingItem
             for (const itemImage of listingItemTemplate.ItemInformation.Images) {
+                const cleanedImageDatas = itemImage.ImageDatas ? itemImage.ImageDatas.map(d => ({ ...d, dataId: '' })) : itemImage.ImageDatas;
+                itemImage.ImageDatas = cleanedImageDatas;
                 imageAddRequest.image = itemImage;
                 const smsgSendResponse: SmsgSendResponse = await this.listingItemImageAddActionService.post(imageAddRequest);
                 results.push(smsgSendResponse);

--- a/src/api/commands/market/MarketPostCommand.ts
+++ b/src/api/commands/market/MarketPostCommand.ts
@@ -298,11 +298,15 @@ export class MarketPostCommand extends BaseCommand implements RpcCommandInterfac
 
         if (!_.isEmpty(promotedMarket.Image)) {
 
+            const image = marketAddRequest.market.Image;
+            const cleanedImageDatas = image.ImageDatas ? image.ImageDatas.map(d => ({ ...d, dataId: '' })) : image.ImageDatas;
+            image.ImageDatas = cleanedImageDatas;
+
             // then prepare the ListingItemImageAddRequest for sending the images
             const imageAddRequest = {
                 sendParams: marketAddRequest.sendParams,
                 market: marketAddRequest.market,
-                image: marketAddRequest.market.Image,
+                image,
                 withData: true
             } as MarketImageAddRequest;
 


### PR DESCRIPTION
 Sending an image (as part of a listing or via market promotion) leaks the source path of the image as stored on the sender's machine. This change remove the image path usage, so that its not included in the sent data.